### PR TITLE
CHAINLINK-36

### DIFF
--- a/ChainLink-Server/util/geocoder.js
+++ b/ChainLink-Server/util/geocoder.js
@@ -4,8 +4,7 @@ module.exports.fetchLocation = async (name, coordinates) => {
     // Fetch based on location name
     if (name) {
         const query = encodeURIComponent(name);
-        const countryCodes = 'us';
-        url = `https://nominatim.openstreetmap.org/search?format=json&q=${query}&countrycodes=${countryCodes}`;
+        url = `https://nominatim.openstreetmap.org/search?format=json&q=${query}`;//&countrycodes=${countryCodes}`; // We are going international baby!
 
     // Fetch based on location coordinates
     } else if (coordinates) {


### PR DESCRIPTION
Removed the US specific lock that was placed on the location query search, it is optional for the API to function. There might be a slight performance hit with this, but in my limited testing it works well enough. I created a ride in Halifax, Canada to test with so you can attempt to search for this. If users still want to find more specific locations they can always include the country in the query, the Open Street Map [Nominatim API](https://nominatim.org/release-docs/latest/api/Search/) should be able to figure it out.

[CHAINLINK-36](https://heartratehackers.atlassian.net/browse/CHAINLINK-36?atlOrigin=eyJpIjoiNDU2ZWVmYzUxOWU4NDhiZDg3ZGFkMjUxYTc0MjE5OGYiLCJwIjoiaiJ9)