### PR TITLE
implement shared password validator on signup and reset screens

### DIFF
--- a/ChainLink-Client/src/routes/SetNewPasswordPage.tsx
+++ b/ChainLink-Client/src/routes/SetNewPasswordPage.tsx
@@ -6,6 +6,7 @@ import LoaderWheel from '../components/LoaderWheel';
 import Footer from '../components/Footer';
 import { useMutation } from '@apollo/client';
 import { RESET_PASSWORD } from '../graphql/mutations/userMutations';
+import { tryValidatePassword } from '../util/PasswordValidator';
 
 const SetNewPasswordPage = () => {
   const navigate = useNavigate();
@@ -49,6 +50,15 @@ const SetNewPasswordPage = () => {
 
     if (!resetToken) {
       setShowErrorsList((prevErrorsList) => [...prevErrorsList, 'Missing token, cannot proceed.']);
+      return;
+    }
+
+    const passwordValidation = tryValidatePassword(newPassword);
+    if (!passwordValidation.isValid) {
+      setShowErrorsList((prevErrorsList) => [
+        ...prevErrorsList,
+        passwordValidation.errorMessage!,
+      ]);
       return;
     }
 

--- a/ChainLink-Client/src/util/PasswordValidator.ts
+++ b/ChainLink-Client/src/util/PasswordValidator.ts
@@ -1,0 +1,21 @@
+interface PasswordValidationResult {
+	isValid: boolean;
+	errorMessage?: string;
+  }
+
+export const tryValidatePassword = (password: string): PasswordValidationResult => {
+	const passwordValidator =
+	  /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-.]).{8,}$/;
+  
+	if (password === '') {
+	  return { isValid: false, errorMessage: 'Password is required' };
+	} else if (!password.match(passwordValidator)) {
+	  return {
+		isValid: false,
+		errorMessage:
+		  'Passwords must be at least 8 characters, must contain at least one lowercase character, one uppercase character, one number, and one special character.',
+	  };
+	}
+  
+	return { isValid: true };
+  };


### PR DESCRIPTION
link to ticket: https://heartratehackers.atlassian.net/browse/CHAINLINK-64

This shares the validation logic between the sign up page and the password reset page to enforce password requirements. We can easily change this now in one place if we want stricter password requirements