### PR TITLE
Chainlink 54 - Profile Panels and Popups Shall Respect Profile's Privacy Setting

### DIFF
--- a/ChainLink-Client/src/components/FriendList.tsx
+++ b/ChainLink-Client/src/components/FriendList.tsx
@@ -93,6 +93,8 @@ const FriendList: React.FC<FriendListProps> = ({ username }) => {
     setSelectedFriend(null);
   };
 
+  const showProfileInfo = (friendSelected != "") && (!featureFlags.privateProfilesEnabled || (!userData?.getUser.isPrivate || !showRequests));
+
   return (
 <div className="profile-page-friends-container">
 
@@ -202,7 +204,10 @@ const FriendList: React.FC<FriendListProps> = ({ username }) => {
               </div>
               <div className="profile-page-panel-name-container">
                 <h3 className="profile-page-panel-name-big" style={{ color: foreColor }}>
-                  <b>{userData.getUser.firstName} {userData.getUser.lastName}</b>
+                    {showProfileInfo ? 
+                        (<b>{userData.getUser.firstName} {userData.getUser.lastName}</b>)
+                     :  (<b>{userData.getUser.username}</b>)
+                    }
 
                   {featureFlags.privateProfilesEnabled && userData?.getUser.isPrivate && (
                       <span className='private-profile-badge'>
@@ -212,7 +217,7 @@ const FriendList: React.FC<FriendListProps> = ({ username }) => {
 
                 </h3>
 
-                {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || !showRequests) ? 
+                {showProfileInfo ? 
                 (
                 <span className="profile-page-panel-name">
                   {`${getUserAge(userData.getUser.birthday)} years old in ${userData.getUser.locationName}`}

--- a/ChainLink-Client/src/components/FriendList.tsx
+++ b/ChainLink-Client/src/components/FriendList.tsx
@@ -6,7 +6,7 @@ import { ACCEPT_FRIEND, DECLINE_FRIEND, REMOVE_FRIEND } from '../graphql/mutatio
 import { FETCH_USER_BY_NAME } from '../graphql/queries/userQueries';
 import UserAvatar from './UserAvatar';
 import '../styles/components/friend-list.css';
-
+import featureFlags from '../featureFlags';
 interface FriendListProps {
   username: string | null;
 }
@@ -188,16 +188,33 @@ const FriendList: React.FC<FriendListProps> = ({ username }) => {
               <div className="profile-page-panel-name-container">
                 <h3 className="profile-page-panel-name-big" style={{ color: foreColor }}>
                   <b>{userData.getUser.firstName} {userData.getUser.lastName}</b>
+
+                  {featureFlags.privateProfilesEnabled && userData?.getUser.isPrivate && (
+                      <span className='private-profile-badge'>
+                          <i className='fa-solid fa-lock'></i>
+                      </span>
+                  )}
+
                 </h3>
+
+                {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || !showRequests) ? 
+                (
                 <span className="profile-page-panel-name">
                   {`${getUserAge(userData.getUser.birthday)} years old in ${userData.getUser.locationName}`}
                 </span>
+                ) : (<></>)}
+
               </div>
             </div>
+
+            {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || !showRequests) ? 
+            (
             <div className="profile-page-panel-content">
               <span className="profile-page-panel-descriptor-left">{userData.getUser.experience}</span>
               <span className="profile-page-panel-descriptor-right">{`${userData.getUser.eventsHosted.length} Rides Joined`}</span>
             </div>
+            ) : (<></>)}
+
             <div className="profile-page-panel-buttons">
               {!showRequests && (
                 <button className="profile-page-panel-reject-button" onClick={() => handleRemoveFriend(friendSelected)}>

--- a/ChainLink-Client/src/components/ProfileModal.tsx
+++ b/ChainLink-Client/src/components/ProfileModal.tsx
@@ -77,7 +77,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, friendStatus }
                         <h3 className="profile-modal-name-big" style={{color: foreColor}}>
                             <b>{userData.getUser.firstName + " " + userData.getUser.lastName}</b>
 
-                            {userData?.getUser.isPrivate && (
+                            {featureFlags.privateProfilesEnabled && userData?.getUser.isPrivate && (
                                 <span className='private-profile-badge'>
                                     <i className='fa-solid fa-lock'></i>
                                 </span>

--- a/ChainLink-Client/src/components/ProfileModal.tsx
+++ b/ChainLink-Client/src/components/ProfileModal.tsx
@@ -74,18 +74,38 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, friendStatus }
                         />
                     </div>
                     <div className="profile-modal-name-container">
-                        <h3 className="profile-modal-name-big" style={{color: foreColor}}><b>{userData.getUser.firstName + " " + userData.getUser.lastName}</b></h3>
-                        {userData.getUser.locationName != "" ? 
-                            (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old in " + userData.getUser.locationName}</span>)
-                        : (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old"}</span>)
-                        }
+                        <h3 className="profile-modal-name-big" style={{color: foreColor}}>
+                            <b>{userData.getUser.firstName + " " + userData.getUser.lastName}</b>
+
+                            {userData?.getUser.isPrivate && (
+                                <span className='private-profile-badge'>
+                                    <i className='fa-solid fa-lock'></i>
+                                </span>
+                            )}
+
+                        </h3>
+
+                        
+
+                        {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || friendStatus == "accepted") ? 
+                        (
+                            userData.getUser.locationName != "" ? 
+                                (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old in " + userData.getUser.locationName}</span>)
+                                : (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old"}</span>)
+                        )
+                        : (<></>)}
                         
                     </div>
                 </div>
-                <div className = "profile-modal-content">
-                    <span className="profile-modal-descriptor-left">{userData.getUser.experience}</span>
-                    <span className="profile-modal-descriptor-right">{userData.getUser.eventsHosted.length + " Rides Joined"}</span>
-                </div>
+
+                {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || friendStatus == "accepted") ? 
+                (
+                    <div className = "profile-modal-content">
+                        <span className="profile-modal-descriptor-left">{userData.getUser.experience}</span>
+                        <span className="profile-modal-descriptor-right">{userData.getUser.eventsHosted.length + " Rides Joined"}</span>
+                    </div>
+                ) : (<div className = "profile-modal-content"></div>)}
+
                 <div className='friend-button-container'>
                     {featureFlags.friendsFeatureEnabled && <FriendButton
                         username={user}

--- a/ChainLink-Client/src/components/ProfileModal.tsx
+++ b/ChainLink-Client/src/components/ProfileModal.tsx
@@ -34,27 +34,30 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, friendStatus }
         },
     });
 
+    
     if (userLoading)
-    {
-        return (
-            <Tooltip 
+        {
+            return (
+                <Tooltip 
                 anchorSelect={"#profile-modal-anchor-" + user} 
                 place="right" openOnClick={true} 
                 className = "popup" 
                 opacity = {100} 
                 border={"3px solid " + foreColor} 
                 style={{backgroundColor: "white", color: foreColor, borderRadius: 10}}
-            >
+                >
             <span>Loading User Profile</span>
             </Tooltip>
         )
     }
 
     if (error != undefined)
-    {
-        return <></>
-    }
-    
+        {
+            return <></>
+        }
+
+    const showProfileInfo = !featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || friendStatus == "accepted")
+        
     return(
         <Tooltip 
             anchorSelect={"#profile-modal-anchor-" + user} 
@@ -75,36 +78,40 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ user, friendStatus }
                     </div>
                     <div className="profile-modal-name-container">
                         <h3 className="profile-modal-name-big" style={{color: foreColor}}>
-                            <b>{userData.getUser.firstName + " " + userData.getUser.lastName}</b>
+                            {showProfileInfo ? 
+                                (<b>{userData.getUser.firstName + " " + userData.getUser.lastName}</b>)
+                                : (<b>{userData.getUser.username}</b>)
+                            }
 
-                            {featureFlags.privateProfilesEnabled && userData?.getUser.isPrivate && (
+                            {!showProfileInfo && (
                                 <span className='private-profile-badge'>
                                     <i className='fa-solid fa-lock'></i>
                                 </span>
                             )}
-
                         </h3>
 
                         
 
-                        {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || friendStatus == "accepted") ? 
+                        {showProfileInfo && 
                         (
                             userData.getUser.locationName != "" ? 
                                 (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old in " + userData.getUser.locationName}</span>)
                                 : (<span className="profile-modal-name">{getUserAge(userData.getUser.birthday) + " year old"}</span>)
-                        )
-                        : (<></>)}
+                        )}
                         
                     </div>
                 </div>
 
-                {!featureFlags.privateProfilesEnabled || (!userData.getUser.isPrivate || friendStatus == "accepted") ? 
+                {showProfileInfo ?
                 (
                     <div className = "profile-modal-content">
                         <span className="profile-modal-descriptor-left">{userData.getUser.experience}</span>
                         <span className="profile-modal-descriptor-right">{userData.getUser.eventsHosted.length + " Rides Joined"}</span>
                     </div>
-                ) : (<div className = "profile-modal-content"></div>)}
+                ) : <div className = "profile-modal-content">
+                        <span className="profile-modal-descriptor-left">Private Profile</span>
+                    </div>
+                }
 
                 <div className='friend-button-container'>
                     {featureFlags.friendsFeatureEnabled && <FriendButton

--- a/ChainLink-Client/src/featureFlags.ts
+++ b/ChainLink-Client/src/featureFlags.ts
@@ -3,7 +3,7 @@ const featureFlags = {
   profilePicturesEnabled: true,
   rideInvitesEnabled: import.meta.env.DEV,
   privateRidesEnabled: import.meta.env.DEV,
-  privateProfilesEnabled: import.meta.env.DEV,
+  privateProfilesEnabled: true,
   notificationsEnabled: import.meta.env.DEV,
   // Add other flags here
   // some other flag when we release it:

--- a/ChainLink-Client/src/featureFlags.ts
+++ b/ChainLink-Client/src/featureFlags.ts
@@ -3,6 +3,7 @@ const featureFlags = {
   profilePicturesEnabled: true,
   rideInvitesEnabled: import.meta.env.DEV,
   privateRidesEnabled: import.meta.env.DEV,
+  privateProfilesEnabled: import.meta.env.DEV
   // Add other flags here
   // some other flag when we release it:
   // nameFeatureEnabled: true,

--- a/ChainLink-Client/src/styles/components/profile-modal.css
+++ b/ChainLink-Client/src/styles/components/profile-modal.css
@@ -33,6 +33,7 @@
 .profile-modal-content {
     display: flex;
     width: 300px;
+    height: 20px;
     margin: 4px 0px;
 }
 
@@ -76,4 +77,9 @@
     margin: 2px 5px;
     float: right;
     text-align: right;
+}
+
+.private-profile-badge {
+    padding-left: 5px;
+    color: black;
 }


### PR DESCRIPTION
Made it so the profile modal and profile panel (in friend list) respect the user's privacy setting. This does make the profile's look very empty (especially on the profile panel) so we may want to fill that space somehow, I toyed with the idea of adding a message indicating the profile is private which helps, but is redundant with the lock icon. If we decide to fill that space that can be a future branch / issue.

[CHAINLINK-54](https://heartratehackers.atlassian.net/browse/CHAINLINK-54)