### PR TITLE
Made it so empty Bike Type is not added to new profiles.

### DIFF
--- a/ChainLink-Client/src/routes/SignupPage.tsx
+++ b/ChainLink-Client/src/routes/SignupPage.tsx
@@ -56,7 +56,7 @@ const SignupPage = () => {
     FTP: 0.0,
     experience: '',
     isPrivate: false,
-    bikeTypes: [''],
+    bikeTypes: [],
   });
 
   // Register mutation

--- a/ChainLink-Client/src/routes/app/RidesFeed.tsx
+++ b/ChainLink-Client/src/routes/app/RidesFeed.tsx
@@ -46,13 +46,29 @@ const RidesFeed = () => {
     onCompleted() {
       setSearchName(userData.getUser.locationName);
       setRadius(userData.getUser.radius);
-      setBikeType(userData.getUser.bikeTypes);
-      setAppliedFilters(userData.getUser.bikeTypes);
+
+      // CHAINLINK-77 Fixed a bug where BikeTypes could be set to [''] on profile creation. That bug was fixed, but the following logic is intended to allow existing users to continue unfettered.
+
+      let bikeTypes = userData.getUser.bikeTypes
+
+      const blankIndex = bikeTypes.indexOf('')
+      if (blankIndex >= 0 && userData.getUser.bikeTypes.length > 1)
+      {
+        bikeTypes.splice(blankIndex, 1)
+      }
+      else if (blankIndex >= 0)
+      {
+        bikeTypes = []
+      }
+
+      setBikeType(bikeTypes);
+      setAppliedFilters(bikeTypes);
+
       setEventParams((prevVals) => ({
         ...prevVals,
         location: userData.getUser.locationName,
         radius: userData.getUser.radius,
-        bikeType: userData.getUser.bikeTypes,
+        bikeType: bikeTypes,
       }));
     },
     variables: {


### PR DESCRIPTION
New profiles were being given a "" Bike Type. This removes that. This empty bike type caused Havok (ie. it made no rides appear) if no other bike type was supplied to the explore query. A server side change could also be implemented to check for this, but I think this should be sufficient. We may want to consider a migration plan for accounts with this property set in production, given the small number of users it may not be very widespread.

[CHAINLINK-77](https://heartratehackers.atlassian.net/browse/CHAINLINK-77)