### PR TITLE
Add preview functionality with preview token generation and preview r…

### DIFF
--- a/ChainLink-Client/src/graphql/mutations/previewMutation.ts
+++ b/ChainLink-Client/src/graphql/mutations/previewMutation.ts
@@ -1,0 +1,7 @@
+import { gql } from "@apollo/client";
+
+export const GENERATE_PREVIEW_TOKEN = gql`
+    mutation GeneratePreviewToken($eventId: String!) {
+        generatePreviewToken(eventID: $eventId)
+    }
+`;

--- a/ChainLink-Client/src/graphql/queries/eventQueries.ts
+++ b/ChainLink-Client/src/graphql/queries/eventQueries.ts
@@ -85,6 +85,11 @@ query getEvent($eventId: String!) {
 }
 `;
 
+export const GENERATE_PREVIEW_TOKEN = gql`
+  mutation GeneratePreviewToken($eventId: String!) {
+    generatePreviewToken(eventID: $eventId)
+}
+`;
 export const GET_HOSTED_EVENTS = gql`
   query getHostedEvents {
     getHostedEvents {

--- a/ChainLink-Client/src/graphql/queries/previewQueries.ts
+++ b/ChainLink-Client/src/graphql/queries/previewQueries.ts
@@ -1,0 +1,31 @@
+import { gql } from '@apollo/client'
+
+export const GET_EVENT_PREVIEW = gql`
+    query GetPreview($jwtToken: String!) {
+        getPreview(jwtToken: $jwtToken) {
+        event {
+                bikeType
+                description
+                difficulty
+                host
+                intensity
+                name
+                participants
+                startTime
+                wattsPerKilo
+            }
+        route {
+                points
+                elevation
+                grade
+                terrain
+                distance
+                maxElevation
+                minElevation
+                totalElevationGain
+                startCoordinates
+                endCoordinates
+            }
+        }
+    }
+    `;

--- a/ChainLink-Server/graphql/resolvers/index.js
+++ b/ChainLink-Server/graphql/resolvers/index.js
@@ -2,6 +2,7 @@ const usersResolver = require("./users");
 const eventsResolver = require("./events");
 const dateScalar = require("./date")
 const friendshipResolver = require("./friendship");
+const previewResolver = require("./preview");
 
 
 module.exports = {
@@ -9,12 +10,14 @@ module.exports = {
         ...usersResolver.Query,
         ...eventsResolver.Query,
         ...friendshipResolver.Query,
+        ...previewResolver.Query,
     },
 
     Mutation: {
         ...usersResolver.Mutation,
         ...eventsResolver.Mutation,
         ...friendshipResolver.Mutation,
+        ...previewResolver.Mutations,
     },
 
     Date: {

--- a/ChainLink-Server/graphql/resolvers/preview.js
+++ b/ChainLink-Server/graphql/resolvers/preview.js
@@ -1,0 +1,59 @@
+const GraphQLError = require('graphql').GraphQLError;
+const Event = require('../../models/Event');
+const Route = require('../../models/Route');
+const { generateJWT, readUrlJwt } = require('../../util/jwtHandler');
+
+module.exports = {
+    Query: {
+        async getPreview(_, __, context) {
+
+            try {
+                // Expected context.payload output
+                // {
+                //     eventID: '67e2ffe13e26e842e9156e9b',
+                //     iat: 1743046244,
+                //     exp: 1743651044
+                // }
+                const payload = context.payload;
+                if (!payload.eventID)
+                    throw new GraphQLError(`Payload does not contain eventID`);
+
+                eventID = payload.eventID;
+                const event = await Event.findById(eventID);
+                if (!event) {
+                    throw new GraphQLError(`Event with ID ${eventID} not found`);
+                }
+
+                if (!event.route) {
+                    throw new GraphQLError(`Event with ID ${eventID} does not have a route associated with it.`);
+                }
+
+                const route = await Route.findById(event.route);
+                if (!route) {
+                    throw new GraphQLError(`Route with ID ${routeID} not found.`);
+                }
+
+                return {
+                    event,
+                    route,
+                };
+            } catch (error) {
+                console.error('Error in getPreview:', error);
+                throw new GraphQLError('Failed to retrieve preview data.');
+            }
+        }
+    },
+
+    Mutations: {
+        generatePreviewToken: (_, { eventID }) => {
+            try {
+                const payload = { eventID };
+                const token = generateJWT(payload, '7d');
+                return token;    
+            } catch (error) {
+                console.error('Error generating token:', error);
+                throw new Error('Failed to generate token.');
+            }   
+        },
+    },
+}

--- a/ChainLink-Server/graphql/typeDefs.js
+++ b/ChainLink-Server/graphql/typeDefs.js
@@ -231,6 +231,11 @@ module.exports = gql`
     endCoordinates: [Float]!
   }
 
+  type Preview {
+    event: Event
+    route: Route
+  }
+
   ## QUERY LIST
   type Query {
     # Users
@@ -256,6 +261,8 @@ module.exports = gql`
     getFriendships(username: String!): [Friendship]
     getFriendStatuses( currentUsername: String!, usernameList: [String]!): [FriendStatus]
     getInvitableFriends(username: String!, eventID: String!): [String]
+    # Preview
+    getPreview(jwtToken: String!): Preview!
   }
 
   type FriendStatus {
@@ -289,6 +296,8 @@ module.exports = gql`
     acceptFriendRequest(sender: String!, receiver: String!): Friendship!
     declineFriendRequest(sender: String!, receiver: String!): Friendship!
     removeFriend(sender: String!, receiver: String!): Friendship!
+    # Previews
+    generatePreviewToken(eventID: String!): String!
   }
     
   type SuccessMessage {

--- a/ChainLink-Server/models/Preview.js
+++ b/ChainLink-Server/models/Preview.js
@@ -1,0 +1,16 @@
+const { model, Schema } = require("mongoose");
+const { Event } = require("./Event.js");
+const { Route } = require("./Route.js");
+
+const previewSchema = new Schema({
+    event: {
+        type: Event,
+        required: true
+    },
+    route: {
+        type: Route,
+        required: true
+    }
+})
+
+module.exports = model('Preview', previewSchema);

--- a/ChainLink-Server/util/jwtHandler.js
+++ b/ChainLink-Server/util/jwtHandler.js
@@ -1,7 +1,11 @@
 const jwt = require('jsonwebtoken');
 const { GraphQLError } = require('graphql');
 
-module.exports.readJWT = (authHeader) => {
+module.exports.generateJWT = (payload, expiresIn = '1h') => {
+    return jwt.sign(payload, process.env.SECRET, { expiresIn });
+}
+
+module.exports.readBearerJWT = (authHeader) => {
     if (authHeader) {
         const token = authHeader.split('Bearer ')[1];
         if (token) {
@@ -23,4 +27,21 @@ module.exports.readJWT = (authHeader) => {
         });
     }
     return null;
+}
+
+module.exports.readUrlJwt = (token) => {
+    if (!token)
+        return null;
+
+    try {
+        // verify will return this on success, be sure to check if it contains what you think it contains
+        const payload = jwt.verify(token, process.env.SECRET);
+        return payload;
+    } catch (err) {
+        throw new GraphQLError('Invalid or expired token', {
+            extensions: {
+                code: 'BAD_REQUEST',
+            }
+        });
+    }
 }


### PR DESCRIPTION
Changelog:
- Added backend logic for jwt token generation
- Added backend logic for verifying tokens
- Added GetPreview and GeneratePreviewToken custom backend requests to front end in previewQueries.ts and previewMutations.ts, respectively

To use the GeneratePreviewToken make sure you send the eventID along with the request. To use GetPreview, take the jwt token from the url and send it as jwtToken along with request. Look to how useQuery is used already in the project to see how to make and send requests with info.